### PR TITLE
Fix `(*Bucket).ForEach`

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -87,6 +87,9 @@ func (bkt *Bucket) CreateBucket(key []byte) (walletdb.ReadWriteBucket, error) {
 		return nil, walletdb.ErrBucketExists
 	}
 
+	// add a new empty value. used for iteration.
+	bkt.Put(key, nil)
+
 	return bkt.tx.createBucket(key, bkt.id), nil
 }
 
@@ -119,6 +122,9 @@ func (bkt *Bucket) DeleteNestedBucket(key []byte) error {
 	}
 
 	bkt.tx.state.buckets = append(bkt.tx.state.buckets[:i], bkt.tx.state.buckets[i+1:]...)
+
+	// delete the empty value.
+	bkt.Delete(key)
 
 	return nil
 }

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -1,0 +1,57 @@
+package tempdb
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/btcsuite/btcwallet/walletdb"
+)
+
+func TestBucketForEach(t *testing.T) {
+	db, err := New("bucket-for-each.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = db.Update(func(tx walletdb.ReadWriteTx) error {
+		// create the root bucket.
+		bkt, err := tx.CreateTopLevelBucket([]byte("alphabet"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		vals := [][]byte{
+			[]byte("a"),
+			[]byte("b"),
+			[]byte("c"),
+		}
+
+		// create all the nested buckets.
+		for _, v := range vals {
+			_, err = bkt.CreateBucket(v)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		var i int
+
+		// iterate over every bucket.
+		return bkt.ForEach(func(k, v []byte) error {
+			if !bytes.Equal(k, vals[i]) {
+				t.Fatalf("expected %s but got %s", k, vals[i])
+			}
+
+			if v != nil {
+				t.Fatalf("expected a value of nil but got %v", v)
+			}
+
+			i++
+
+			return nil
+		})
+	}, reset)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
`(*Bucket).ForEach` is supposed to iterate key/values **and nested buckets**, when implementing this I'd not been aware of the nested buckets part.

this should be covered by `walletdb.TestInterface`, I'll file a bug.