### PR TITLE
fix: open returns ErrDBDoesNotExist

### DIFF
--- a/tempdb.go
+++ b/tempdb.go
@@ -107,12 +107,17 @@ func New(args ...any) (walletdb.DB, error) {
 	}, nil
 }
 
+// Open returns ErrDbDoesNotExist, because tempdb is not yet perisitent
+func Open(args ...any) (walletdb.DB, error) {
+	return nil, walletdb.ErrDbDoesNotExist
+}
+
 func init() {
 	err := walletdb.RegisterDriver(walletdb.Driver{
 		DbType: "tempdb",
 
 		Create: New,
-		Open:   New,
+		Open:   Open,
 	})
 
 	if err != nil {

--- a/tempdb.go
+++ b/tempdb.go
@@ -107,7 +107,7 @@ func New(args ...any) (walletdb.DB, error) {
 	}, nil
 }
 
-// Open returns ErrDbDoesNotExist, because tempdb is not yet perisitent
+// Open always returns `walletdb.ErrDbDoesNotExist` because tempdb is not persistent.
 func Open(args ...any) (walletdb.DB, error) {
 	return nil, walletdb.ErrDbDoesNotExist
 }


### PR DESCRIPTION
Because this database isn't persistent, Open should always return ErrDBDoesNotExist in order to be compatible with other databases.

This is an issue in the asset minter, because it tries to open the database and if it doesn't exist, it then creates it and runs an intialization to create buckets that are needed.